### PR TITLE
Update to RabbitmqQueueLogger

### DIFF
--- a/src/RabbitmqQueueLogger.php
+++ b/src/RabbitmqQueueLogger.php
@@ -93,6 +93,8 @@ class RabbitmqQueueLogger implements \iRAP\Logging\LoggerInterface
             $context = print_r($context, true);
         }
         
+        $message = $this->serviceName($message);
+        
         $logArray = array(
             'level' => $level,
             'timestamp' => time(),
@@ -119,4 +121,18 @@ class RabbitmqQueueLogger implements \iRAP\Logging\LoggerInterface
         $this->log(\iRAP\Logging\LogLevel::WARNING, $message, $context);
     }
 
+    /**
+     * Method which will add the value of SERVICE_NAME to the log message as a prefix,
+     * if that constant is defined and is not already incorporated into the message
+     */
+    protected function serviceName($message)
+    {
+        if(!defined("SERVICE_NAME")) {
+            return $message;
+        }
+        if(strpos($message,SERVICE_NAME) > -1) {
+            return $message;
+        }
+        return SERVICE_NAME.': '.$message;
+    }
 }


### PR DESCRIPTION
Added a method to prefix the supplied message with the value of the 'SERVICE_NAME' constant if it is defined and not already in the message.