### PR TITLE
Update PHP-AMQPlib version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "php-amqplib/php-amqplib": "3.0.*",
+        "php-amqplib/php-amqplib": "3.*",
         "irap/logging" : "2.0.*"
     },
     "autoload": {


### PR DESCRIPTION
Updated version of PHP-AMQPLib to not be dependant on minor version.  Ie changed from 3.0.* to 3.*